### PR TITLE
Views Load More calls it after loading the next chunk of items.

### DIFF
--- a/templates/menu_tree/menu_tree.js
+++ b/templates/menu_tree/menu_tree.js
@@ -6,7 +6,10 @@
 (function ($) {
   Drupal.behaviors.ecEuropaMenuTree = {
     attach: function (context) {
-      ECL.megamenu('.ecl-navigation-menu__root');
+      if(!Drupal.behaviors.ecEuropaMenuTree.megamenu) {
+        ECL.megamenu('.ecl-navigation-menu__root');
+        Drupal.behaviors.ecEuropaMenuTree.megamenu = true;
+      }
     }
   };
 })(jQuery);


### PR DESCRIPTION
After loading more items via view load more, this function is triggered and the main menu doesn't work anymore.
I think there are other behaviors that must be reviewed to avoid these side effects.
https://www.lullabot.com/articles/understanding-javascript-behaviors-in-drupal