### PR TITLE
Issue #122: Prevent the class ecl-editor to be added on the atomium-overview page.

### DIFF
--- a/templates/block/block.component.inc
+++ b/templates/block/block.component.inc
@@ -191,5 +191,9 @@ function ec_europa_preprocess_block(array &$variables, $hook) {
  * Implements hook_preprocess_hook().
  */
 function ec_europa_preprocess_block__content(array &$variables, $hook) {
+  if ($_GET['q'] === 'atomium-overview') {
+    return;
+  }
+
   $variables['atomium']['attributes']['content']->append('class', 'ecl-editor');
 }


### PR DESCRIPTION
Fix #122 