### PR TITLE
NEPT-2668: Make Language selector compatible with content translation.

### DIFF
--- a/templates/lang_select_site/lang_select_site.component.inc
+++ b/templates/lang_select_site/lang_select_site.component.inc
@@ -49,22 +49,24 @@ function ec_europa_preprocess_lang_select_site(array &$variables, $hook) {
   $languages_list = language_list('enabled');
   $variables['code'] = $language_current->language;
   $variables['label'] = $language_current->name;
+  $destination = drupal_get_destination();
+  $translations = translation_path_get_translations($destination['destination']);
 
   $variables['url'] = url(
     'language-selector/site-language', array(
       'html' => TRUE,
       'query' => array(
-        drupal_get_destination(),
+        $destination,
       ),
     )
   );
 
   // Build the list of links.
-  $languages = \array_map(function ($language) use ($variables) {
+  $languages = \array_map(function ($language) use ($variables, $translations) {
     return array(
       '#theme' => _atomium_extend_theme_hook('link', $variables['theme_hook_original']),
       '#text' => $language->name,
-      '#path' => current_path(),
+      '#path' => (isset($translations[$language->language])) ? $translations[$language->language] : current_path(),
       '#options' => array(
         'attributes' => array(
           'class' => array(


### PR DESCRIPTION
## NEPT-2668

### Description

Make Language selector compatible with content translation, language selector did not work when multilingual support was enabled with node translation.

### Change log

- Changed: ec_europa_preprocess_lang_select_site()
