### PR TITLE
NEPT-2489: Fix Illegal string offset 'content' 

### DIFF
--- a/templates/easy_breadcrumb/easy_breadcrumb.component.inc
+++ b/templates/easy_breadcrumb/easy_breadcrumb.component.inc
@@ -126,7 +126,7 @@ function ec_europa_preprocess_easy_breadcrumb(array &$variables, $hook) {
  * Generate the first breadcrumb items basing on a custom menu.
  */
 function _ec_europa_breadcrumb_menu(&$variables) {
-  module_load_include('inc', 'easy_breadcrumb', 'includes/easy_breadcrumb.blocks');
+  $variables['breadcrumb'] = _easy_breadcrumb_build_items();
 
   $menu_links = menu_tree('menu-breadcrumb-menu');
   $new_items = array();


### PR DESCRIPTION
NEPT-2489

Fixed Warning: Illegal string offset 'content' in ec_europa_preprocess_easy_breadcrumb() (line 96 of /home/ec2-user/environment/platform/profiles/multisite_drupal_standard/themes/ec_europa/templates/easy_breadcrumb/easy_breadcrumb.component.inc).

This was reverted in 0.0.19 due to function undefined error, but higher easy_breadcrumb version it works.